### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/research/deeplab/g3doc/installation.md
+++ b/research/deeplab/g3doc/installation.md
@@ -25,7 +25,7 @@ pip install tensorflow-gpu
 The remaining libraries can be installed on Ubuntu 14.04 using via apt-get:
 
 ```bash
-sudo apt-get install python-pil python-numpy
+sudo apt-get --no-install-recommends install python-pil python-numpy
 pip install --user jupyter
 pip install --user matplotlib
 pip install --user PrettyTable

--- a/research/object_detection/dockerfiles/android/Dockerfile
+++ b/research/object_detection/dockerfiles/android/Dockerfile
@@ -26,14 +26,14 @@ RUN git clone --depth 1 https://github.com/tensorflow/models.git && \
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk -y
+    apt-get update -y && apt-get --no-install-recommends install google-cloud-sdk -y
 
 
 # Install the Tensorflow Object Detection API from here
 # https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/installation.md
 
 # Install object detection api dependencies
-RUN apt-get install -y protobuf-compiler python-pil python-lxml python-tk && \
+RUN apt-get --no-install-recommends install -y protobuf-compiler python-pil python-lxml python-tk && \
     pip install Cython && \
     pip install contextlib2 && \
     pip install jupyter && \
@@ -64,7 +64,7 @@ ENV PYTHONPATH $PYTHONPATH:/tensorflow/models/research:/tensorflow/models/resear
 
 # Install wget (to make life easier below) and editors (to allow people to edit
 # the files inside the container)
-RUN apt-get install -y wget vim emacs nano
+RUN apt-get --no-install-recommends install -y wget vim emacs nano
 
 
 # Grab various data files which are used throughout the demo: dataset,

--- a/research/object_detection/g3doc/installation.md
+++ b/research/object_detection/g3doc/installation.md
@@ -30,7 +30,7 @@ pip install tensorflow-gpu
 The remaining libraries can be installed on Ubuntu 16.04 using via apt-get:
 
 ``` bash
-sudo apt-get install protobuf-compiler python-pil python-lxml python-tk
+sudo apt-get --no-install-recommends install protobuf-compiler python-pil python-lxml python-tk
 pip install --user Cython
 pip install --user contextlib2
 pip install --user jupyter

--- a/research/syntaxnet/Dockerfile
+++ b/research/syntaxnet/Dockerfile
@@ -9,7 +9,7 @@ ENV SYNTAXNETDIR=/opt/tensorflow PATH=$PATH:/root/bin
 RUN mkdir -p $SYNTAXNETDIR \
     && cd $SYNTAXNETDIR \
     && apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
           file \
           git \
           graphviz \

--- a/research/syntaxnet/docker-devel/Dockerfile-test-base
+++ b/research/syntaxnet/docker-devel/Dockerfile-test-base
@@ -9,7 +9,7 @@ ENV SYNTAXNETDIR=/opt/tensorflow PATH=$PATH:/root/bin
 RUN mkdir -p $SYNTAXNETDIR \
     && cd $SYNTAXNETDIR \
     && apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
           file \
           git \
           graphviz \

--- a/research/syntaxnet/docker-devel/Dockerfile.min
+++ b/research/syntaxnet/docker-devel/Dockerfile.min
@@ -8,7 +8,7 @@ FROM ubuntu:16.04
 ENV SYNTAXNETDIR=/opt/tensorflow PATH=$PATH:/root/bin
 
 RUN apt-get update \
-    && apt-get install -y \
+    && apt-get --no-install-recommends install -y \
           file \
           git \
           graphviz \

--- a/samples/languages/java/docker/Dockerfile
+++ b/samples/languages/java/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM tensorflow/tensorflow:1.4.0
 WORKDIR /
 RUN apt-get update
-RUN apt-get -y install maven openjdk-8-jdk
+RUN apt-get --no-install-recommends -y install maven openjdk-8-jdk
 RUN mvn dependency:get -Dartifact=org.tensorflow:tensorflow:1.4.0
 RUN mvn dependency:get -Dartifact=org.tensorflow:proto:1.4.0
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

results in smaller image size.